### PR TITLE
fix(di/service_collection): make `add_instance` work by delegating to a singleton factory

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wd-di"
-version = "0.2.6"
+version = "0.2.7"
 description = ".NET Core Dependency Injection for Python"
 readme = "README.md"
 authors = [

--- a/src/wd/di/service_collection.py
+++ b/src/wd/di/service_collection.py
@@ -73,12 +73,15 @@ class ServiceCollection:
     
     def add_instance(self, service_type: Type, instance: Any):
         """
-        Register an already constructed instance as a singleton service.
-        This instance will be returned whenever service_type is requested.
+        Register an *already-constructed* object as a singleton.
+
+        We implement this by delegating to `add_singleton_factory`, wrapping the
+        instance in a trivial factory (`lambda _: instance`).  That lets the
+        existing provider logic—already designed to call factories for singletons—
+        do all the work, without touching `ServiceProvider`.
         """
-        descriptor = ServiceDescriptor(service_type, lifetime=ServiceLifetime.SINGLETON)
-        descriptor.instance = instance
-        self._services[service_type] = descriptor
+        # The lambda’s sole parameter is the ServiceProvider; it’s unused.
+        self.add_singleton_factory(service_type, lambda _: instance)
 
     def configure(
         self, options_type: Type[T], *, section: Optional[str] = None


### PR DESCRIPTION
Fix: `add_instance()` now behaves like a proper singleton registration

---

### Problem

Registering an already constructed object with
`services.add_instance(Logger, Logger())` raised an exception at resolution time:

```
Service descriptor for <class 'infrastructure.logging_service.Logger'> has no implementation type or factory.
```

### Root cause

`ServiceProvider.get_service()` only knows how to build singletons from an implementation type or an implementation factory. The original `add_instance()` stored the object directly on `descriptor.instance`, which the provider never consulted.

### Solution

Re-implement `add_instance()` so it delegates to `add_singleton_factory`, wrapping the supplied object in a trivial factory:

```python
self.add_singleton_factory(service_type, lambda _: instance)
```

This reuses the existing singleton logic, keeps the provider unchanged, and removes the failure.

### Files changed

* **src/wd/di/service\_collection.py**

  * Replaced the custom `descriptor.instance` handling with the factory-based implementation.
  * Updated the docstring to explain the new behavior.

### How to verify

1. Run the example that previously failed:

   ```bash
   python examples/order_processor/main.py
   ```

   Expected output (no exception):

   ```
   [LOG]: Processing order: order001
   [LOG]: Order saved: order001
   [LOG]: Order processed: order001
   ```

2. Optional unit test:

   ```python
   def test_add_instance_returns_same_object():
       services = ServiceCollection()
       logger = Logger()
       services.add_instance(Logger, logger)
       provider = services.build_service_provider()
       assert provider.get_service(Logger) is logger
   ```

### Why this approach

* Fix is localized to `ServiceCollection`; no new branches in the provider's hot path.
* Reuses the well-tested singleton factory flow, preserving thread safety and caching semantics.
* Zero runtime overhead after the first resolution.
